### PR TITLE
Update pre-2021 stuff

### DIFF
--- a/.github/workflows/packages-list
+++ b/.github/workflows/packages-list
@@ -67,6 +67,7 @@ eclass/libtool.eclass
 eclass/linux-info.eclass
 eclass/linux-mod.eclass
 eclass/llvm.eclass
+eclass/ltprune.eclass
 eclass/meson.eclass
 eclass/multilib-build.eclass
 eclass/multilib-minimal.eclass
@@ -74,6 +75,7 @@ eclass/multilib.eclass
 eclass/ninja-utils.eclass
 eclass/optfeature.eclass
 eclass/pax-utils.eclass
+eclass/perl-functions.eclass
 eclass/prefix.eclass
 eclass/tmpfiles.eclass
 eclass/toolchain-funcs.eclass
@@ -82,6 +84,7 @@ eclass/verify-sig.eclass
 eclass/vim-doc.eclass
 eclass/vim-plugin.eclass
 eclass/virtualx.eclass
+eclass/wrapper.eclass
 
 net-analyzer/nmap
 
@@ -94,6 +97,7 @@ net-misc/rsync
 
 sys-apps/gentoo-functions
 sys-apps/help2man
+sys-apps/iucode_tool
 
 sys-devel/autoconf
 sys-devel/autoconf-archive

--- a/eclass/ltprune.eclass
+++ b/eclass/ltprune.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ltprune.eclass
@@ -12,7 +12,7 @@
 #
 # Discouraged. Whenever possible, please use much simpler:
 # @CODE
-# find "${ED}" -name '*.la' -delete || die
+# find "${ED}" -type f -name '*.la' -delete || die
 # @CODE
 
 if [[ -z ${_LTPRUNE_ECLASS} ]]; then

--- a/eclass/wrapper.eclass
+++ b/eclass/wrapper.eclass
@@ -1,10 +1,16 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: wrapper.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: create a shell wrapper script
+
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ -z ${_WRAPPER_ECLASS} ]]; then
 _WRAPPER_ECLASS=1
@@ -19,7 +25,6 @@ _WRAPPER_ECLASS=1
 make_wrapper() {
 	local wrapper=$1 bin=$2 chdir=$3 libdir=$4 path=$5
 	local tmpwrapper="${T}/tmp.wrapper.${wrapper##*/}"
-	has "${EAPI:-0}" 0 1 2 && local EPREFIX=""
 
 	(
 	echo '#!/bin/sh'
@@ -30,11 +35,11 @@ make_wrapper() {
 		else
 			var=LD_LIBRARY_PATH
 		fi
-		cat <<-EOF
+		sed 's/^X//' <<-EOF || die
 			if [ "\${${var}+set}" = "set" ] ; then
-				export ${var}="\${${var}}:${EPREFIX}${libdir}"
+			X	export ${var}="\${${var}}:${EPREFIX}${libdir}"
 			else
-				export ${var}="${EPREFIX}${libdir}"
+			X	export ${var}="${EPREFIX}${libdir}"
 			fi
 		EOF
 	fi
@@ -52,7 +57,7 @@ make_wrapper() {
 		newexe "${tmpwrapper}" "${wrapper}"
 		) || die
 	else
-		newbin "${tmpwrapper}" "${wrapper}" || die
+		newbin "${tmpwrapper}" "${wrapper}"
 	fi
 }
 

--- a/sys-apps/iucode_tool/files/iucode_tool-2.3.1-limits-include.patch
+++ b/sys-apps/iucode_tool/files/iucode_tool-2.3.1-limits-include.patch
@@ -1,0 +1,10 @@
+Fixes build on musl.
+--- a/iucode_tool.c
++++ b/iucode_tool.c
+@@ -29,6 +29,7 @@
+ #include <assert.h>
+ #include <argp.h>
+ #include <dirent.h>
++#include <limits.h>
+ #include <time.h>
+ #include <cpuid.h>

--- a/sys-apps/iucode_tool/iucode_tool-2.3.1-r1.ebuild
+++ b/sys-apps/iucode_tool/iucode_tool-2.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -10,6 +10,12 @@ SRC_URI="https://gitlab.com/iucode-tool/releases/raw/master/${PN/_/-}_${PV}.tar.
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE=""
+
+RDEPEND="elibc_musl? ( sys-libs/argp-standalone )"
+DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${PN/_/-}-${PV}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.3.1-limits-include.patch
+)

--- a/sys-apps/iucode_tool/metadata.xml
+++ b/sys-apps/iucode_tool/metadata.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>base-system@gentoo.org</email>
-	<name>Gentoo Base System</name>
-</maintainer>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="gitlab">iucode-tool/iucode-tool</remote-id>
+		<remote-id type="gitlab">iucode-tool/releases</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
- eclass/ltprune:
  - doc fixes

- eclass/perl-functions:
  - dropped support for old EAPI 5 and 6
  - bash cosmetics

- ~eclass/selinux-policy-2:~
  - ~contains my fix for patch applying~
  - ~skips unconfined on MCS/MLS policy types~

- eclass/wrapper:
  - dropped support for EAPIs older than 5
  - has some weird trick for keeping the indentation intact

- sys-apps/iucode_tool:
  - still at 2.3.1-r1
  - adds some patch

There's nothing changeloggable.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/263/cldsv/

@tormath1 : I'm updating the selinux eclass here. If you prefer to keep it as is and update it as a part of your selinux update effort, please let me know - I'll drop it from the PR.

EDIT: Nevermind, dropped selinux eclass update - it caused some issues with selinux-virt package (an empty patch or something).