### PR TITLE
Fix dev-libs/openssl build in stable channel

### DIFF
--- a/eclass/edo.eclass
+++ b/eclass/edo.eclass
@@ -1,0 +1,48 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: edo.eclass
+# @MAINTAINER:
+# QA Team <qa@gentoo.org>
+# @AUTHOR:
+# Sam James <sam@gentoo.org>
+# @SUPPORTED_EAPIS: 7 8
+# @BLURB: Convenience function to run commands verbosely and die on failure
+# @DESCRIPTION:
+# This eclass provides the 'edo' command, and an 'edob' variant for ebegin/eend,
+# which logs the command used verbosely and dies (exits) on failure.
+#
+# This eclass should be used only where needed to give a more verbose log, e.g.
+# for invoking non-standard ./configure scripts, or building objects/binaries
+# directly within ebuilds via compiler invocations. It is NOT to be used
+# in place of generic 'command || die' where verbosity is unnecessary.
+case ${EAPI} in
+	7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+if [[ -z ${_EDO_ECLASS} ]] ; then
+_EDO_ECLASS=1
+
+# @FUNCTION: edo
+# @USAGE: <command> [<args>...]
+# @DESCRIPTION:
+# Executes a short 'command' with any given arguments and exits on failure
+# unless called under 'nonfatal'.
+edo() {
+	einfo "$@"
+	"$@" || die -n "Failed to run command: $@"
+}
+
+# @FUNCTION: edob
+# @USAGE: <command> [<args>...]
+# @DESCRIPTION:
+# Executes 'command' with ebegin & eend with any given arguments and exits
+# on failure unless called under 'nonfatal'.
+edob() {
+	ebegin "Running $@"
+	"$@"
+	eend $? || die -n "Failed to run command: $@"
+}
+
+fi


### PR DESCRIPTION
Add edo.eclass from Gentoo.

It's from Gentoo commit 6ce8bc59bc81e8a509570c7364e7177bdc181b16.

The dev-libs/openssl package started to use the edo eclass, which was not available yet in stable channel. Add it.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/701/cldsv

- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
