### PR TITLE
.github: add monthly workflow update-metadata-glsa

### DIFF
--- a/.github/workflows/update-metadata-glsa.yml
+++ b/.github/workflows/update-metadata-glsa.yml
@@ -1,0 +1,32 @@
+name: Keep GLSA metadata updated
+on:
+  schedule:
+    - cron:  '0 7 1 * *'
+  workflow_dispatch:
+
+jobs:
+  keep-glsa-metadata-updated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout portage-stable
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update GLSA metadata
+        id: update-glsa-metadata
+        run: |
+          rm -rf metadata/glsa
+          mkdir --parents metadata/glsa
+          rsync --archive rsync://rsync.gentoo.org/gentoo-portage/metadata/glsa/* ./metadata/glsa/
+          todaydate=$(date +%Y-%m-%d)
+          echo "TODAYDATE=${todaydate}" >>"${GITHUB_OUTPUT}"
+      - name: Create pull request for main branch
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: buildbot/monthly-glsa-metadata-updates-${{steps.update-glsa-metadata.outputs.TODAYDATE }}
+          delete-branch: true
+          base: main
+          title: Monthly GLSA metadata ${{steps.update-glsa-metadata.outputs.TODAYDATE }}
+          body: Updated GLSA metadata
+          labels: main

--- a/.github/workflows/update-packages-from-list.yml
+++ b/.github/workflows/update-packages-from-list.yml
@@ -20,13 +20,14 @@ jobs:
           path: gentoo
           # Gentoo is quite a large repo, so limit ourselves to last
           # quarter milion of commits. It is about two years worth of changes.
+          # Is is needed by the sync script to find out the hash of the last commit
+          # that made the changes to the package.
           fetch-depth: 250000
           ref: master
       - name: Checkout build scripts
         uses: actions/checkout@v3
         with:
           repository: flatcar/flatcar-build-scripts
-          ref: krnowak/stuff
           path: flatcar-build-scripts
       - name: Update listed packages
         id: update-listed-packages


### PR DESCRIPTION
Add a new monthly workflow `update-metadata-glsa`, to sync GLSA(Gentoo Linux Security Advisories) with upstream Gentoo.

While most individual metadata xml files are available on the upstream [mirror](https://github.com/gentoo-mirror/gentoo), its binary data as well as timestamp files do not exist on the public Git repo. So it is necessary to first rsync those data from `rsync.gentoo.org`, before actually running `sync-with-gentoo` script.

Remove unnecessary options in `update-packages-from-list`. As we already merged necessary changes for `sync-with-gentoo` into master branch of the flatcar-build-scripts repo, it is not necessary any more to point to `krnowak/stuff` branch. Remove it.

The checkout action of the Github Actions defaults to `fetch-depth=1`, when no fetch-depth is given. So it is better for efficiency not to specify fetch-depth.

## Testing done

Tested from my own [fork](https://github.com/dongsupark/portage-stable).
