### PR TITLE
.github: set Author name to update-metadata-glsa

### DIFF
--- a/.github/workflows/update-metadata-glsa.yml
+++ b/.github/workflows/update-metadata-glsa.yml
@@ -30,4 +30,5 @@ jobs:
           title: Monthly GLSA metadata ${{steps.update-glsa-metadata.outputs.TODAYDATE }}
           body: Updated GLSA metadata
           commit-message: "metadata: Monthly GLSA metadata updates"
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
           labels: main


### PR DESCRIPTION
Set a correct Author name and its email address to the commit message of monthly GLSA metadata PRs, `Flatcar Buildbot <buildbot@flatcar-linux.org>`.