### PR TITLE
scripts/bootstrap: fix verbose bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -277,10 +277,6 @@ for atom in portage.settings.packages:
 [[ -z ${myTEXINFO}    ]] && myTEXINFO="sys-apps/texinfo"
 [[ -z ${myZLIB}       ]] && myZLIB="sys-libs/zlib"
 [[ -z ${myNCURSES}    ]] && myNCURSES="sys-libs/ncurses"
-# Flatcar: install curl with BOOTSTRAP_USE=ssl to fetch from https URLs
-[[ -z ${myCURL}       ]] && myCURL="net-misc/curl"
-# Flatcar: upgrade to openssl-3 before system rebuild in stage3
-[[ -z ${myOPENSSL}    ]] && myOPENSSL="dev-libs/openssl"
 
 # Do we really want gettext/nls?
 [[ ${USE_NLS} != 1 ]] && myGETTEXT=
@@ -302,10 +298,6 @@ einfo "Using libc       : ${myLIBC}"
 einfo "Using texinfo    : ${myTEXINFO}"
 einfo "Using zlib       : ${myZLIB}"
 einfo "Using ncurses    : ${myNCURSES}"
-# Flatcar: install curl with BOOTSTRAP_USE=ssl to fetch from https URLs
-einfo "Using curl       : ${myCURL}"
-# Flatcar: upgrade to openssl-3 before system rebuild in stage3
-einfo "Using openssl    : ${myOPENSSL}"
 echo -------------------------------------------------------------------------------
 show_status 1 Configuring environment
 echo -------------------------------------------------------------------------------
@@ -328,8 +320,7 @@ if [ ${BOOTSTRAP_STAGE} -le 1 ] ; then
 	echo -------------------------------------------------------------------------------
 	set_bootstrap_stage 2
 fi
-# Flatcar: Add openmp and static-libs to fix catalyst bootstrap stage2.
-export USE="-* bootstrap ${ALLOWED_USE} ${BOOTSTRAP_USE} openmp static-libs"
+export USE="-* bootstrap ${ALLOWED_USE} ${BOOTSTRAP_USE}"
 
 # We can't unmerge headers which may or may not exist yet. If your
 # trying to use nptl, it may be needed to flush out any old headers
@@ -341,12 +332,9 @@ if [ ${BOOTSTRAP_STAGE} -le 2 ] ; then
 		STRAP_EMERGE_OPTS="${STRAP_EMERGE_OPTS} --resume"
 		cp /var/run/bootstrap-mtimedb /var/cache/edb
 	else
-		# Flatcar: install curl with BOOTSTRAP_USE=ssl to fetch from https URLs
 		STRAP_EMERGE_POSARGS="\
 			${myOS_HEADERS} ${myTEXINFO} ${myGETTEXT} ${myBINUTILS} \
-			${myGCC} ${myLIBC} ${myCURL} ${myBASELAYOUT} ${myZLIB}"
-		# Flatcar: upgrade to openssl-3 before system rebuild in stage3
-		STRAP_EMERGE_POSARGS="${STRAP_EMERGE_POSARGS} ${myOPENSSL}"
+			${myGCC} ${myLIBC} ${myBASELAYOUT} ${myZLIB}"
 	fi
 	${V_ECHO} emerge ${STRAP_EMERGE_OPTS} ${STRAP_EMERGE_POSARGS} || cleanup 1
 	echo -------------------------------------------------------------------------------

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -277,6 +277,10 @@ for atom in portage.settings.packages:
 [[ -z ${myTEXINFO}    ]] && myTEXINFO="sys-apps/texinfo"
 [[ -z ${myZLIB}       ]] && myZLIB="sys-libs/zlib"
 [[ -z ${myNCURSES}    ]] && myNCURSES="sys-libs/ncurses"
+# Flatcar: install curl with BOOTSTRAP_USE=ssl to fetch from https URLs
+[[ -z ${myCURL}       ]] && myCURL="net-misc/curl"
+# Flatcar: upgrade to openssl-3 before system rebuild in stage3
+[[ -z ${myOPENSSL}    ]] && myOPENSSL="dev-libs/openssl"
 
 # Do we really want gettext/nls?
 [[ ${USE_NLS} != 1 ]] && myGETTEXT=
@@ -298,6 +302,10 @@ einfo "Using libc       : ${myLIBC}"
 einfo "Using texinfo    : ${myTEXINFO}"
 einfo "Using zlib       : ${myZLIB}"
 einfo "Using ncurses    : ${myNCURSES}"
+# Flatcar: install curl with BOOTSTRAP_USE=ssl to fetch from https URLs
+einfo "Using curl       : ${myCURL}"
+# Flatcar: upgrade to openssl-3 before system rebuild in stage3
+einfo "Using openssl    : ${myOPENSSL}"
 echo -------------------------------------------------------------------------------
 show_status 1 Configuring environment
 echo -------------------------------------------------------------------------------
@@ -320,7 +328,8 @@ if [ ${BOOTSTRAP_STAGE} -le 1 ] ; then
 	echo -------------------------------------------------------------------------------
 	set_bootstrap_stage 2
 fi
-export USE="-* bootstrap ${ALLOWED_USE} ${BOOTSTRAP_USE}"
+# Flatcar: Add openmp and static-libs to fix catalyst bootstrap stage2.
+export USE="-* bootstrap ${ALLOWED_USE} ${BOOTSTRAP_USE} openmp static-libs"
 
 # We can't unmerge headers which may or may not exist yet. If your
 # trying to use nptl, it may be needed to flush out any old headers
@@ -332,9 +341,12 @@ if [ ${BOOTSTRAP_STAGE} -le 2 ] ; then
 		STRAP_EMERGE_OPTS="${STRAP_EMERGE_OPTS} --resume"
 		cp /var/run/bootstrap-mtimedb /var/cache/edb
 	else
+		# Flatcar: install curl with BOOTSTRAP_USE=ssl to fetch from https URLs
 		STRAP_EMERGE_POSARGS="\
 			${myOS_HEADERS} ${myTEXINFO} ${myGETTEXT} ${myBINUTILS} \
-			${myGCC} ${myLIBC} ${myBASELAYOUT} ${myZLIB}"
+			${myGCC} ${myLIBC} ${myCURL} ${myBASELAYOUT} ${myZLIB}"
+		# Flatcar: upgrade to openssl-3 before system rebuild in stage3
+		STRAP_EMERGE_POSARGS="${STRAP_EMERGE_POSARGS} ${myOPENSSL}"
 	fi
 	${V_ECHO} emerge ${STRAP_EMERGE_OPTS} ${STRAP_EMERGE_POSARGS} || cleanup 1
 	echo -------------------------------------------------------------------------------
@@ -345,10 +357,17 @@ fi
 if [[ -n ${STRAP_RUN} ]] ; then
 	if [[ -x ${GCC_CONFIG} ]] && ${GCC_CONFIG} --get-current-profile &>/dev/null
 	then
-		# Make sure we get the old gcc unmerged ...
-		${V_ECHO} emerge ${STRAP_EMERGE_OPTS} --prune sys-devel/gcc || cleanup 1
-		# Make sure the profile and /lib/cpp and /usr/bin/cc are valid ...
-		${GCC_CONFIG} "$(${GCC_CONFIG} --get-current-profile)" &>/dev/null
+		# Flatcar: avoid failures when bootstraping in verbose mode
+		output=$(${V_ECHO} emerge ${STRAP_EMERGE_OPTS} --prune --pretend --quiet sys-devel/gcc 2>/dev/null)
+		if [[ ${DEBUG} = "1" ]] ; then
+			echo "${output}"
+		fi
+		if [[ "${output}" = *'All selected packages:'* ]] ; then
+			# Make sure we get the old gcc unmerged ...
+			${V_ECHO} emerge ${STRAP_EMERGE_OPTS} --prune sys-devel/gcc || cleanup 1
+			# Make sure the profile and /lib/cpp and /usr/bin/cc are valid ...
+			${GCC_CONFIG} "$(${GCC_CONFIG} --get-current-profile)" &>/dev/null
+		fi
 	fi
 fi
 


### PR DESCRIPTION
This fixes stage2 of the SDK build when catalyst in run in verbose mode.

CI passed: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/632/cldsv/

Also filed to upstream: https://github.com/gentoo/gentoo/pull/29612
